### PR TITLE
Sync to mirror

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -218,7 +218,7 @@ cd ~/git/dockerApache/nextcloud
 ./sync-to-mirror.sh
 
 # Or via cron (credentials must be cached or passwordless sudo configured):
-0 3 * * * /home/hannes/git/dockerApache/nextcloud/sync-to-mirror.sh
+0 3 * * * /home/hannes/git/dockerApache/nextcloud/sync-to-mirror.sh >> /var/log/nc-mirror-$(date +\%Y\%m\%d).log 2>&1
 ```
 
 > **Important:** `sync-to-mirror.sh` uses `sudo rsync` to read the `www-data`-owned

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -149,30 +149,43 @@ hits Fritz!Box's own HTTPS interface → Fritz!Box returns its error page.
 
 ```
 ┌─ home WiFi ─────────────────────────────────────────────┐
-│  mobile → DNS query: nextcloud.mxtracks.info            │
-│         ← dnsmasq on latitude: 192.168.178.129  ✓      │
+│  mobile → DNS query direct to dnsmasq (192.168.178.129) │
+│         ← 192.168.178.129  ✓  (A + AAAA overridden)    │
 │  mobile → HTTPS 192.168.178.129:443 (reverse proxy)     │
 │         ← Nextcloud  ✓                                  │
 └─────────────────────────────────────────────────────────┘
 ```
 
-1. In `.env` set `NEXTCLOUD_LOCAL_IP=192.168.178.129` (latitude's LAN IP).
+1. In `.env`:
+   ```dotenv
+   NEXTCLOUD_LOCAL_IP=192.168.178.129          # latitude LAN IPv4
+   NEXTCLOUD_LOCAL_IPV6=fdf4:be15:98e0:...     # latitude stable ULA IPv6
+   DNS_UPSTREAM=8.8.8.8                        # upstream for all other queries
+   ```
 2. Start dnsmasq: `docker compose --profile split-dns up -d`
-3. **Network-wide** – in Fritz!Box under **Internet → Zugangsdaten → DNS-Server**:
-   - *Bevorzugter DNSv4-Server*  : `192.168.178.129` (latitude / dnsmasq)
-   - *Alternativer DNSv4-Server* : `8.8.8.8` (Google DNS, fallback if latitude is down)
-   - Set `DNS_UPSTREAM=8.8.8.8` in `.env` — **not** `192.168.178.1` (Fritz!Box),
-     which would create an infinite loop: Fritz!Box → dnsmasq → Fritz!Box → …  
-   **Per-device** – set the phone's WiFi DNS to `192.168.178.129`;
-   with per-device config `DNS_UPSTREAM=192.168.178.1` is fine (no loop).
-4. The Fritz!Box **DNS-Rebind-Schutz** exception for `nextcloud.mxtracks.info`
-   must remain in place (it allows the private-IP DNS response to pass through).
-5. On Android set **Private DNS → Off** (not "Automatic").
+3. The Fritz!Box **DNS-Rebind-Schutz** exception for `nextcloud.mxtracks.info`
+   must remain in place (Heimnetz → Netzwerk → DNS-Rebind-Schutz).
+4. On Android set **Private DNS → Off** (not "Automatic").
    Fritz!Box supports DoT on port 853; "Automatic" makes Android use Fritz!Box's
    DoT resolver which handles queries *internally*, bypassing dnsmasq entirely.
 
-dnsmasq answers `nextcloud.mxtracks.info → 192.168.178.129` and forwards all
-other queries to `DNS_UPSTREAM`, so normal internet DNS is unaffected.
+### ⚠️ Fritz!Box-wide DNS-Server setting does NOT work for this setup
+
+`nextcloud.mxtracks.info` is a CNAME to `*.myfritz.net` (Fritz!Box's own
+MyFRITZ DDNS domain). Fritz!Box resolves `*.myfritz.net` **internally** —
+it never forwards those queries to the configured upstream DNS. Even with
+*Bevorzugter DNSv4-Server* = `192.168.178.129`, Fritz!Box "sees through" the
+CNAME and returns its public IP directly.
+
+**The only reliable fix is per-device DNS on Android:**
+
+> WiFi settings → long-press network → Modify → Advanced →
+> IP settings: **Static** → **DNS 1**: `192.168.178.129`, **DNS 2**: `8.8.8.8`
+
+This bypasses Fritz!Box's resolver entirely and talks straight to dnsmasq.
+
+dnsmasq overrides both A (IPv4) and AAAA (IPv6) records for `OVERWRITEHOST`
+and forwards all other queries to `DNS_UPSTREAM`, so normal internet DNS is unaffected.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -139,6 +139,43 @@ On **Linux** use the host's LAN IP for `ProxyPass` (not `host.docker.internal`).
 
 ---
 
+## Fritz!Box NAT hairpinning / split DNS
+
+Fritz!Box does **not** support NAT loopback. When a LAN device accesses
+`nextcloud.mxtracks.info`, its DNS resolves to the public IP → the request
+hits Fritz!Box's own HTTPS interface → Fritz!Box returns its error page.
+
+### Fix: split DNS with the optional dnsmasq service
+
+```
+┌─ home WiFi ─────────────────────────────────────────────┐
+│  mobile → DNS query: nextcloud.mxtracks.info            │
+│         ← dnsmasq on latitude: 192.168.178.129  ✓      │
+│  mobile → HTTPS 192.168.178.129:443 (reverse proxy)     │
+│         ← Nextcloud  ✓                                  │
+└─────────────────────────────────────────────────────────┘
+```
+
+1. In `.env` set `NEXTCLOUD_LOCAL_IP=192.168.178.129` (latitude's LAN IP).
+2. Start dnsmasq: `docker compose --profile split-dns up -d`
+3. **Network-wide** – in Fritz!Box under **Internet → Zugangsdaten → DNS-Server**:
+   - *Bevorzugter DNSv4-Server*  : `192.168.178.129` (latitude / dnsmasq)
+   - *Alternativer DNSv4-Server* : `8.8.8.8` (Google DNS, fallback if latitude is down)
+   - Set `DNS_UPSTREAM=8.8.8.8` in `.env` — **not** `192.168.178.1` (Fritz!Box),
+     which would create an infinite loop: Fritz!Box → dnsmasq → Fritz!Box → …  
+   **Per-device** – set the phone's WiFi DNS to `192.168.178.129`;
+   with per-device config `DNS_UPSTREAM=192.168.178.1` is fine (no loop).
+4. The Fritz!Box **DNS-Rebind-Schutz** exception for `nextcloud.mxtracks.info`
+   must remain in place (it allows the private-IP DNS response to pass through).
+5. On Android set **Private DNS → Off** (not "Automatic").
+   Fritz!Box supports DoT on port 853; "Automatic" makes Android use Fritz!Box's
+   DoT resolver which handles queries *internally*, bypassing dnsmasq entirely.
+
+dnsmasq answers `nextcloud.mxtracks.info → 192.168.178.129` and forwards all
+other queries to `DNS_UPSTREAM`, so normal internet DNS is unaffected.
+
+---
+
 ## Mirror sync (`sync-to-mirror.sh`)
 
 ### Topology

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,6 +73,9 @@ dockerApache/
 - Use `sudo mkdir -p`, `sudo rsync`, `sudo chown -R www-data:root` for data dirs.
 - Use `tee -a "$LOG"` to stream output to both screen and log file.
 - `convmv -f iso-8859-1 -t utf-8 -r --notest` after rsync to fix Latin-1 filenames.
+- Scripts that use `sudo` **must be run directly on the server** (interactive login
+  or cron), not via a non-interactive `ssh host './script.sh'` pipe — sudo requires
+  a terminal or cached credentials.
 
 ### Backup / restore pattern
 - Backups: timestamped sub-folders under `./backups/YYYYMMDD_HHMMSS/`.
@@ -136,6 +139,59 @@ On **Linux** use the host's LAN IP for `ProxyPass` (not `host.docker.internal`).
 
 ---
 
+## Mirror sync (`sync-to-mirror.sh`)
+
+### Topology
+| Role | Host | OS | Data path |
+|------|------|----|-----------|
+| **Source** (production) | `latitude` | Ubuntu Linux | `NEXTCLOUD_DATA_DIR=/media/hannes/T5` |
+| **Mirror** (standby) | `mac2016` | macOS | `MIRROR_DATA_DIR=/Volumes/SamsungT1` |
+
+The script is **always run on the source server** (`latitude`).  
+It SSHes into the mirror (`mac2016`) to run Docker Compose commands there.
+
+### What it does (in order)
+1. Enable maintenance mode on source
+2. Enable maintenance mode on mirror (suppress errors if not yet set up)
+3. Stream PostgreSQL dump source → mirror via SSH pipe (`pg_dump | ssh | psql`)
+4. Stream `config/` + `custom_apps/` via tar pipe; patch `config.php` on mirror
+   (strips `overwritehost`/`overwriteprotocol`, updates DB credentials)
+5. Rsync `data/` incrementally source → mirror (`sudo rsync` — data owned by `www-data`)
+6. `docker compose down && docker compose up -d` on mirror so the entrypoint
+   re-populates `html/`; wait up to 20 min for `versioncheck.php` to appear
+7. `occ upgrade` + `occ maintenance:repair` on mirror
+8. Set `trusted_domains` on mirror to `localhost` + `$MIRROR_HOST`
+9. Disable maintenance mode on mirror, then on source
+
+### Key `.env` variables for sync
+```dotenv
+MIRROR_HOST=mac2016               # SSH hostname of the mirror
+MIRROR_USER=hannes                # SSH user on the mirror
+MIRROR_SSH_PORT=22
+MIRROR_NEXTCLOUD_DIR=/Users/hannes/git/dockerApache/nextcloud  # compose dir on mirror
+MIRROR_DATA_DIR=/Volumes/SamsungT1  # data root on mirror (if different from compose dir)
+MIRROR_EXTRA_PATH=/usr/local/bin    # prepended to PATH on mirror (Docker Desktop on macOS)
+MIRROR_SHELL=zsh                    # login shell on mirror (zsh for macOS, bash for Linux)
+```
+
+### Running the sync
+```bash
+# On the source server (must be an interactive/sudo-capable session):
+cd ~/git/dockerApache/nextcloud
+./sync-to-mirror.sh
+
+# Or via cron (credentials must be cached or passwordless sudo configured):
+0 3 * * * /home/hannes/git/dockerApache/nextcloud/sync-to-mirror.sh
+```
+
+> **Important:** `sync-to-mirror.sh` uses `sudo rsync` to read the `www-data`-owned
+> data directory. It must be run in a session where `sudo` can authenticate
+> (interactive login with cached credentials). Running it via a non-interactive
+> `ssh latitude './sync-to-mirror.sh'` will fail with
+> *"sudo: a terminal is required to read the password"*.
+
+---
+
 ## ownCloud migration
 `nextcloud/migrate-from-owncloud.sh` handles:
 1. User discovery via `occ user:list` (or filesystem scan fallback).
@@ -153,4 +209,3 @@ OWNCLOUD_URL=http://localhost/owncloud
 OWNCLOUD_ADMIN_USER=admin
 OWNCLOUD_ADMIN_PASSWORD=secret
 ```
-

--- a/README.md
+++ b/README.md
@@ -215,3 +215,45 @@ Files must be placed under:
 $NEXTCLOUD_DATA_DIR/nextcloud/data/<username>/files/
 ```
 
+---
+
+### LAN access / Fritz!Box NAT hairpinning fix
+
+When Nextcloud is behind a Fritz!Box and you access it via the public domain
+(`nextcloud.mxtracks.info`) **from inside the same home WiFi**, Fritz!Box
+intercepts the request instead of forwarding it — you get a Fritz!Box error page.
+
+**Fix: start the optional `dnsmasq` split-DNS service** so LAN devices resolve
+the domain to latitude's **local IP** instead of the public one.
+
+```bash
+# Add to nextcloud/.env:
+NEXTCLOUD_LOCAL_IP=192.168.178.129          # latitude's LAN IPv4
+NEXTCLOUD_LOCAL_IPV6=fdf4:be15:...          # latitude's LAN IPv6 (ip -6 addr show scope global)
+DNS_UPSTREAM=8.8.8.8                        # upstream DNS (not Fritz!Box – avoids loop)
+
+# Start dnsmasq
+docker compose --profile split-dns up -d
+```
+
+Then in Fritz!Box **Internet → Zugangsdaten → DNS-Server**:
+- *Bevorzugter DNSv4-Server*  : `192.168.178.129`
+- *Alternativer DNSv4-Server* : `8.8.8.8`
+
+Keep the **DNS-Rebind-Schutz** exception for `nextcloud.mxtracks.info` in place
+(Heimnetz → Netzwerk → DNS-Rebind-Schutz).
+
+#### Android: disable Private DNS — must be "Off", not "Automatic"
+
+Android 9+ has a **Private DNS** feature that bypasses the network DNS:
+
+> Settings → Network & internet → Advanced → **Private DNS** → set to **Off**
+
+⚠️ **"Automatic" is NOT enough** — Fritz!Box supports DNS-over-TLS (DoT) on
+port 853. When Private DNS is set to *Automatic*, Android connects to Fritz!Box's
+DoT port directly, and Fritz!Box handles those queries **internally** without
+going through dnsmasq. The result: `nextcloud.mxtracks.info` still resolves to
+the public IP and the Fritz!Box error page reappears.
+
+Only **"Off"** forces Android to use plain UDP/TCP DNS via Fritz!Box → dnsmasq → local IP.
+

--- a/README.md
+++ b/README.md
@@ -236,24 +236,80 @@ DNS_UPSTREAM=8.8.8.8                        # upstream DNS (not Fritz!Box – av
 docker compose --profile split-dns up -d
 ```
 
-Then in Fritz!Box **Internet → Zugangsdaten → DNS-Server**:
-- *Bevorzugter DNSv4-Server*  : `192.168.178.129`
-- *Alternativer DNSv4-Server* : `8.8.8.8`
-
 Keep the **DNS-Rebind-Schutz** exception for `nextcloud.mxtracks.info` in place
 (Heimnetz → Netzwerk → DNS-Rebind-Schutz).
 
-#### Android: disable Private DNS — must be "Off", not "Automatic"
+#### ⚠️ Fritz!Box-wide DNS setting does NOT work for MyFRITZ domains
 
-Android 9+ has a **Private DNS** feature that bypasses the network DNS:
+Setting *Bevorzugter DNSv4-Server* to `192.168.178.129` in
+**Internet → Zugangsdaten → DNS-Server** is **not enough** when the Nextcloud
+domain is a CNAME pointing to `*.myfritz.net`:
 
-> Settings → Network & internet → Advanced → **Private DNS** → set to **Off**
+```
+nextcloud.mxtracks.info.  CNAME  xyqvgh0pmfs04c1b.myfritz.net.
+```
 
-⚠️ **"Automatic" is NOT enough** — Fritz!Box supports DNS-over-TLS (DoT) on
-port 853. When Private DNS is set to *Automatic*, Android connects to Fritz!Box's
-DoT port directly, and Fritz!Box handles those queries **internally** without
-going through dnsmasq. The result: `nextcloud.mxtracks.info` still resolves to
-the public IP and the Fritz!Box error page reappears.
+Fritz!Box resolves its own MyFRITZ hostnames **internally** — it never forwards
+those queries to our dnsmasq. Clients must query dnsmasq directly:
 
-Only **"Off"** forces Android to use plain UDP/TCP DNS via Fritz!Box → dnsmasq → local IP.
+---
 
+#### Fix A — Per-device: static DNS in Android WiFi settings
+
+Android 10 and earlier:
+> Settings → Wi-Fi → **long-press** network → Modify network → Advanced options
+> → IP settings: **Static** → DNS 1: `192.168.178.129`
+
+Android 12 – 16 (new UI, long-press removed):
+> Settings → Network & internet → Internet → tap the **⚙️ gear icon** next to
+> your Wi-Fi network → tap the **✏️ pencil icon** (top-right) → IP settings:
+> **Static** → DNS 1: `192.168.178.129`, DNS 2: `8.8.8.8`
+
+Also set **Private DNS → Off** (Settings → Network & internet → Private DNS).
+
+---
+
+#### Fix B — Android Private DNS with DoT (works on ALL Android versions)
+
+Android's *Private DNS* feature uses **DNS-over-TLS (DoT)** on port 853.
+Point it at `nextcloud.mxtracks.info` — Android resolves that hostname via
+Fritz!Box (gets the public IP), connects to port 853, Fritz!Box forwards it to
+latitude's CoreDNS service (which holds the valid Let's Encrypt cert), and from
+then on all DNS goes through dnsmasq → local IP. ✓
+
+**One-time setup:**
+
+1. Add to `nextcloud/.env`:
+   ```dotenv
+   DOT_CERT_DIR=/etc/letsencrypt/live/nextcloud.mxtracks.info-0002
+   ```
+
+2. Start both services:
+   ```bash
+   docker compose --profile split-dns --profile dot up -d
+   ```
+
+3. In Fritz!Box → **Heimnetz → Portfreigaben**: add a port forward:
+   - Protocol: **TCP**
+   - External port: **853**
+   - Internal host: **192.168.178.129** (latitude)
+   - Internal port: **853**
+
+4. On Android:
+   > Settings → Network & internet → **Private DNS**
+   > → *Private DNS provider hostname* → `nextcloud.mxtracks.info`
+
+No static IP needed — works automatically on home WiFi **and** over mobile data.
+
+---
+
+#### IPv6 / Happy Eyeballs
+
+Android prefers IPv6. Without an AAAA override in dnsmasq, Android receives
+the public IPv6 address and bypasses local routing. Set `NEXTCLOUD_LOCAL_IPV6`
+in `.env` to latitude's stable ULA IPv6 address:
+
+```bash
+# Find latitude's stable ULA address (scope global, not temporary):
+ip -6 addr show scope global | grep -v temporary
+```

--- a/nextcloud/.env.example
+++ b/nextcloud/.env.example
@@ -79,7 +79,8 @@ NEXTCLOUD_TRUSTED_DOMAINS="localhost 192.168.1.100 cloud.example.com"
 OVERWRITEHOST=nextcloud.mxtracks.info
 OVERWRITEPROTOCOL=https
 OVERWRITECLIURL=https://nextcloud.mxtracks.info
-TRUSTED_PROXIES=192.168.1.1
+# LAN IP of the reverse proxy (Apache2 on latitude → 192.168.178.129)
+TRUSTED_PROXIES=192.168.178.129
 
 # PHP limits
 PHP_MEMORY_LIMIT=512M
@@ -90,22 +91,27 @@ PHP_UPLOAD_LIMIT=10G
 # the router's public IP are NOT forwarded back to internal hosts.  Result:
 # mobile on home WiFi → nextcloud.mxtracks.info → hits Fritz!Box error page.
 #
-# Fix: run the optional dnsmasq service so that LAN clients which use latitude
-# as their DNS server resolve OVERWRITEHOST → NEXTCLOUD_LOCAL_IP directly.
+# Additional complication: nextcloud.mxtracks.info is a CNAME to *.myfritz.net.
+# Fritz!Box resolves *.myfritz.net INTERNALLY regardless of the configured
+# upstream DNS → setting Fritz!Box's DNSv4-Server to latitude has no effect.
 #
-# Steps:
-#   1. Set NEXTCLOUD_LOCAL_IP to latitude's LAN address.
-#   2. Start dnsmasq:  docker compose --profile split-dns up -d
-#   3a. Fritz!Box fix (network-wide):
-#         Internet → Zugangsdaten → DNS-Server
-#           Bevorzugter DNSv4-Server  : 192.168.178.129   (latitude / dnsmasq)
-#           Alternativer DNSv4-Server : 8.8.8.8            (Google – fallback)
-#         ⚠ Use DNS_UPSTREAM=8.8.8.8 (not Fritz!Box 192.168.178.1) to avoid a
-#           forwarding loop: Fritz!Box → dnsmasq → Fritz!Box → dnsmasq …
-#   3b. Per-device only (phone WiFi settings → DNS = 192.168.178.129):
-#         DNS_UPSTREAM=192.168.178.1 is fine here – phone bypasses Fritz!Box
-#         directly, so no loop.
-#   4. The DNS-Rebind-Schutz exception for OVERWRITEHOST is still required ✓
+# Fix A – per-device static DNS (Android WiFi settings):
+#   Settings → Network & internet → Internet → ⚙️ gear → ✏️ edit
+#   IP settings: Static → DNS 1: 192.168.178.129, DNS 2: 8.8.8.8
+#
+# Fix B – Android Private DNS (DoT) – works on ALL Android versions:
+#   1. Start BOTH profiles:
+#        docker compose --profile split-dns --profile dot up -d
+#   2. Fritz!Box → Heimnetz → Portfreigaben: 853 TCP → 192.168.178.129:853
+#   3. Android: Settings → Network & internet → Private DNS
+#        → "Private DNS provider hostname" → nextcloud.mxtracks.info
+#
+# Steps common to both fixes:
+#   • Start dnsmasq: docker compose --profile split-dns up -d
+#   • Keep the DNS-Rebind-Schutz exception for OVERWRITEHOST in Fritz!Box
+#   • On Android: Private DNS must be "Off" (Fix A) or custom hostname (Fix B)
+#   • DNS_UPSTREAM must NOT be Fritz!Box (192.168.178.1) – use 8.8.8.8 to
+#     avoid a forwarding loop: Fritz!Box → dnsmasq → Fritz!Box → …
 #
 # NEXTCLOUD_LOCAL_IP – latitude's LAN IP (bind address for dnsmasq port 53)
 NEXTCLOUD_LOCAL_IP=192.168.178.129
@@ -113,7 +119,10 @@ NEXTCLOUD_LOCAL_IP=192.168.178.129
 # dnsmasq returns this for AAAA queries so Android/IPv6 clients stay on the LAN too.
 NEXTCLOUD_LOCAL_IPV6=fdf4:be15:98e0:0:162:361:f85d:ef9b
 # DNS_UPSTREAM – upstream resolver dnsmasq forwards unknown queries to.
-#   Fritz!Box-wide (step 3a): set to a public DNS to avoid loop → 8.8.8.8
-#   Per-device only (step 3b): Fritz!Box is fine              → 192.168.178.1
 DNS_UPSTREAM=8.8.8.8
+
+# ─── DNS-over-TLS / CoreDNS (Fix B – Android Private DNS) ────────────────────
+# Path to the Let's Encrypt "live" directory containing fullchain.pem + privkey.pem
+# for the OVERWRITEHOST certificate (must match the hostname in Android Private DNS).
+DOT_CERT_DIR=/etc/letsencrypt/live/nextcloud.mxtracks.info-0002
 

--- a/nextcloud/.env.example
+++ b/nextcloud/.env.example
@@ -109,6 +109,9 @@ PHP_UPLOAD_LIMIT=10G
 #
 # NEXTCLOUD_LOCAL_IP – latitude's LAN IP (bind address for dnsmasq port 53)
 NEXTCLOUD_LOCAL_IP=192.168.178.129
+# NEXTCLOUD_LOCAL_IPV6 – latitude's stable ULA IPv6 (get with: ip -6 addr show scope global | grep mngtmpaddr)
+# dnsmasq returns this for AAAA queries so Android/IPv6 clients stay on the LAN too.
+NEXTCLOUD_LOCAL_IPV6=fdf4:be15:98e0:0:162:361:f85d:ef9b
 # DNS_UPSTREAM – upstream resolver dnsmasq forwards unknown queries to.
 #   Fritz!Box-wide (step 3a): set to a public DNS to avoid loop → 8.8.8.8
 #   Per-device only (step 3b): Fritz!Box is fine              → 192.168.178.1

--- a/nextcloud/.env.example
+++ b/nextcloud/.env.example
@@ -85,3 +85,32 @@ TRUSTED_PROXIES=192.168.1.1
 PHP_MEMORY_LIMIT=512M
 PHP_UPLOAD_LIMIT=10G
 
+# ─── Split-DNS / NAT-loopback (Fritz!Box workaround) ─────────────────────────
+# Fritz!Box does not support NAT hairpinning: connections from LAN clients to
+# the router's public IP are NOT forwarded back to internal hosts.  Result:
+# mobile on home WiFi → nextcloud.mxtracks.info → hits Fritz!Box error page.
+#
+# Fix: run the optional dnsmasq service so that LAN clients which use latitude
+# as their DNS server resolve OVERWRITEHOST → NEXTCLOUD_LOCAL_IP directly.
+#
+# Steps:
+#   1. Set NEXTCLOUD_LOCAL_IP to latitude's LAN address.
+#   2. Start dnsmasq:  docker compose --profile split-dns up -d
+#   3a. Fritz!Box fix (network-wide):
+#         Internet → Zugangsdaten → DNS-Server
+#           Bevorzugter DNSv4-Server  : 192.168.178.129   (latitude / dnsmasq)
+#           Alternativer DNSv4-Server : 8.8.8.8            (Google – fallback)
+#         ⚠ Use DNS_UPSTREAM=8.8.8.8 (not Fritz!Box 192.168.178.1) to avoid a
+#           forwarding loop: Fritz!Box → dnsmasq → Fritz!Box → dnsmasq …
+#   3b. Per-device only (phone WiFi settings → DNS = 192.168.178.129):
+#         DNS_UPSTREAM=192.168.178.1 is fine here – phone bypasses Fritz!Box
+#         directly, so no loop.
+#   4. The DNS-Rebind-Schutz exception for OVERWRITEHOST is still required ✓
+#
+# NEXTCLOUD_LOCAL_IP – latitude's LAN IP (bind address for dnsmasq port 53)
+NEXTCLOUD_LOCAL_IP=192.168.178.129
+# DNS_UPSTREAM – upstream resolver dnsmasq forwards unknown queries to.
+#   Fritz!Box-wide (step 3a): set to a public DNS to avoid loop → 8.8.8.8
+#   Per-device only (step 3b): Fritz!Box is fine              → 192.168.178.1
+DNS_UPSTREAM=8.8.8.8
+

--- a/nextcloud/.env.example
+++ b/nextcloud/.env.example
@@ -65,6 +65,22 @@ NEXTCLOUD_ADMIN_PASSWORD=changeme_admin
 #
 NEXTCLOUD_TRUSTED_DOMAINS="localhost 192.168.1.100 cloud.example.com"
 
+# ─── Reverse proxy / HTTPS overrides ─────────────────────────────────────────
+# Required when Nextcloud runs on HTTP internally but is served via an HTTPS
+# reverse proxy (nginx, Apache, Fritz!Box, Caddy, …).
+# Without these, Nextcloud generates http://localhost/… URLs for CardDAV,
+# CalDAV and WebDAV – mobile clients follow those literally and get a 404.
+#
+# OVERWRITEHOST     – the public hostname (no scheme, no port)
+# OVERWRITEPROTOCOL – "https" (or "http" if you don't terminate TLS)
+# OVERWRITECLIURL   – full public URL used by cron / CLI commands
+# TRUSTED_PROXIES   – space-separated LAN IPs of your reverse proxy
+#
+OVERWRITEHOST=nextcloud.mxtracks.info
+OVERWRITEPROTOCOL=https
+OVERWRITECLIURL=https://nextcloud.mxtracks.info
+TRUSTED_PROXIES=192.168.1.1
+
 # PHP limits
 PHP_MEMORY_LIMIT=512M
 PHP_UPLOAD_LIMIT=10G

--- a/nextcloud/.env.example
+++ b/nextcloud/.env.example
@@ -3,6 +3,24 @@
 # Override on the command line:  NEXTCLOUD_DATA_DIR=/mnt/storage docker compose up -d
 NEXTCLOUD_DATA_DIR=./data
 
+# ─── Mirror sync (used by sync-to-mirror.sh) ─────────────────────────────────
+# SSH user@host of the mirror machine
+MIRROR_HOST=mirror.example.com
+MIRROR_USER=hannes
+MIRROR_SSH_PORT=22
+# Path on the mirror where the nextcloud docker-compose.yml lives
+MIRROR_NEXTCLOUD_DIR=/opt/nextcloud
+# Data root on the mirror (= NEXTCLOUD_DATA_DIR on the mirror host).
+# Only needed when the compose folder and data folder differ on the mirror.
+# Example: compose is at /Users/hannes/git/dockerApache/nextcloud
+#          but data is on an external drive at /Volumes/SamsungT1
+# If unset it defaults to MIRROR_NEXTCLOUD_DIR.
+MIRROR_DATA_DIR=/Volumes/SamsungT1
+# Extra PATH prepended on mirror if docker is not found in the default PATH
+# macOS Docker Desktop: /usr/local/bin  or  /Applications/Docker.app/Contents/Resources/bin
+# Linux: usually not needed
+MIRROR_EXTRA_PATH=/usr/local/bin
+
 # ─── Migration from ownCloud (used by migrate-from-owncloud.sh) ──────────────
 OWNCLOUD_DATA_DIR=/srv/www/vhosts/mxdocs/owncloud/data
 OWNCLOUD_OCC=/srv/www/vhosts/mxdocs/owncloud/occ

--- a/nextcloud/Corefile.dot
+++ b/nextcloud/Corefile.dot
@@ -1,0 +1,8 @@
+tls://.:853 {
+    tls {$DOT_CERT_DIR}/fullchain.pem {$DOT_CERT_DIR}/privkey.pem
+    forward . {$NEXTCLOUD_LOCAL_IP}:53
+    log
+}
+
+
+

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -58,6 +58,12 @@ services:
       # Nextcloud trusted domains (comma-separated)
       NEXTCLOUD_TRUSTED_DOMAINS: ${NEXTCLOUD_TRUSTED_DOMAINS:-localhost}
 
+      # Reverse proxy / URL overrides (needed when behind nginx/Apache HTTPS proxy)
+      OVERWRITEHOST: ${OVERWRITEHOST:-}
+      OVERWRITEPROTOCOL: ${OVERWRITEPROTOCOL:-}
+      OVERWRITECLIURL: ${OVERWRITECLIURL:-}
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
+
       # Redis for caching & locking
       REDIS_HOST: redis
 

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -82,26 +82,37 @@ services:
       - nextcloud_net
 
   # ── Optional: split-DNS for NAT-loopback workaround ──────────────────────
-  # Enable by setting DNSMASQ_ENABLED=true in .env.
   # Clients that use latitude as their DNS server will resolve
   # OVERWRITEHOST → NEXTCLOUD_LOCAL_IP directly, bypassing Fritz!Box NAT.
+  # Uses host networking so dnsmasq binds the LAN interface directly
+  # (avoids Docker UDP proxy issues).
   dnsmasq:
-    image: drewonthenet/dnsmasq:latest
+    image: alpine:3.19
     restart: unless-stopped
     profiles:
       - split-dns
-    ports:
-      - "${NEXTCLOUD_LOCAL_IP:-0.0.0.0}:53:53/udp"
-      - "${NEXTCLOUD_LOCAL_IP:-0.0.0.0}:53:53/tcp"
+    network_mode: host
     cap_add:
       - NET_ADMIN
-    command: >
-      --no-resolv
-      --server=${DNS_UPSTREAM:-192.168.178.1}
-      --address=/${OVERWRITEHOST:-nextcloud.example.com}/${NEXTCLOUD_LOCAL_IP:-127.0.0.1}
-      --log-queries
-    networks:
-      - nextcloud_net
+    environment:
+      DNS_UPSTREAM: ${DNS_UPSTREAM:-8.8.8.8}
+      OVERWRITEHOST: ${OVERWRITEHOST:-nextcloud.example.com}
+      NEXTCLOUD_LOCAL_IP: ${NEXTCLOUD_LOCAL_IP:-127.0.0.1}
+      NEXTCLOUD_LOCAL_IPV6: ${NEXTCLOUD_LOCAL_IPV6:-}
+    entrypoint: []
+    command:
+      - /bin/sh
+      - -c
+      - >-
+        apk add --no-cache dnsmasq >/dev/null 2>&1 &&
+        exec dnsmasq --no-daemon --no-resolv
+        --listen-address=$$NEXTCLOUD_LOCAL_IP
+        --bind-interfaces
+        --server=$$DNS_UPSTREAM
+        --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IP
+        --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IPV6
+        --filter-rr=HTTPS
+        --log-queries --log-facility=-
 
 networks:
   nextcloud_net:

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -81,6 +81,38 @@ services:
     networks:
       - nextcloud_net
 
+  # ── Optional: DNS-over-TLS (DoT) frontend for Android Private DNS ────────
+  # Wraps dnsmasq with TLS on port 853 using the existing Let's Encrypt cert.
+  # Android "Private DNS" → nextcloud.mxtracks.info (DoT) → this container
+  #   → dnsmasq:53 → local IP for the Nextcloud domain.
+  #
+  # Requires:
+  #   - split-dns profile active (dnsmasq must be running on port 53)
+  #   - DOT_CERT_DIR in .env pointing to the Let's Encrypt live directory
+  #   - Fritz!Box port-forward:  853 TCP → 192.168.178.129:853
+  #
+  # Start both together:
+  #   docker compose --profile split-dns --profile dot up -d
+  coredns-dot:
+    image: coredns/coredns:1.11.3
+    restart: unless-stopped
+    profiles:
+      - dot
+    user: root
+    ports:
+      - "853:853/tcp"
+    environment:
+      NEXTCLOUD_LOCAL_IP: ${NEXTCLOUD_LOCAL_IP:-192.168.178.129}
+      DOT_CERT_DIR: ${DOT_CERT_DIR:-/etc/letsencrypt/live/nextcloud.mxtracks.info-0002}
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./Corefile.dot:/Corefile:ro
+    command:
+      - -conf
+      - /Corefile
+    networks:
+      - nextcloud_net
+
   # ── Optional: split-DNS for NAT-loopback workaround ──────────────────────
   # Clients that use latitude as their DNS server will resolve
   # OVERWRITEHOST → NEXTCLOUD_LOCAL_IP directly, bypassing Fritz!Box NAT.
@@ -112,9 +144,12 @@ services:
           --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IP
           --filter-rr=HTTPS
           --log-queries --log-facility=-"
-        # Only add AAAA record when an IPv6 address is configured
+        # When an IPv6 address is configured: also listen on it and return AAAA
+        # This allows Fritz!Box DNSv6-Server to point here as well,
+        # so AAAA queries for OVERWRITEHOST are answered with the local ULA address
+        # instead of the public IPv6 (which Android would prefer via Happy Eyeballs).
         if [ -n "$$NEXTCLOUD_LOCAL_IPV6" ]; then
-          ARGS="$$ARGS --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IPV6"
+          ARGS="$$ARGS --listen-address=$$NEXTCLOUD_LOCAL_IPV6 --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IPV6"
         fi
         exec dnsmasq $$ARGS
 

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -103,16 +103,20 @@ services:
     command:
       - /bin/sh
       - -c
-      - >-
-        apk add --no-cache dnsmasq >/dev/null 2>&1 &&
-        exec dnsmasq --no-daemon --no-resolv
-        --listen-address=$$NEXTCLOUD_LOCAL_IP
-        --bind-interfaces
-        --server=$$DNS_UPSTREAM
-        --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IP
-        --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IPV6
-        --filter-rr=HTTPS
-        --log-queries --log-facility=-
+      - |
+        apk add --no-cache dnsmasq >/dev/null 2>&1
+        ARGS="--no-daemon --no-resolv
+          --listen-address=$$NEXTCLOUD_LOCAL_IP
+          --bind-interfaces
+          --server=$$DNS_UPSTREAM
+          --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IP
+          --filter-rr=HTTPS
+          --log-queries --log-facility=-"
+        # Only add AAAA record when an IPv6 address is configured
+        if [ -n "$$NEXTCLOUD_LOCAL_IPV6" ]; then
+          ARGS="$$ARGS --address=/$$OVERWRITEHOST/$$NEXTCLOUD_LOCAL_IPV6"
+        fi
+        exec dnsmasq $$ARGS
 
 networks:
   nextcloud_net:

--- a/nextcloud/docker-compose.yml
+++ b/nextcloud/docker-compose.yml
@@ -4,6 +4,14 @@ version: "3.9"
 #   NEXTCLOUD_DATA_DIR=/your/data/path docker compose up -d
 # Or copy .env.example to .env and adjust values before running:
 #   docker compose up -d
+#
+# Split-DNS / NAT-loopback (Fritz!Box):
+#   If mobile clients on the same LAN get Fritz!Box's error page instead of
+#   Nextcloud, enable the dnsmasq service:
+#     DNSMASQ_ENABLED=true   (in .env)
+#   Then point Fritz!Box or mobile DNS to latitude's LAN IP.
+#   dnsmasq answers nextcloud.<your-domain> → NEXTCLOUD_LOCAL_IP and
+#   forwards all other queries upstream (Fritz!Box / 192.168.178.1).
 
 services:
   db:
@@ -70,6 +78,28 @@ services:
       # PHP memory limit
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT:-512M}
       PHP_UPLOAD_LIMIT: ${PHP_UPLOAD_LIMIT:-10G}
+    networks:
+      - nextcloud_net
+
+  # ── Optional: split-DNS for NAT-loopback workaround ──────────────────────
+  # Enable by setting DNSMASQ_ENABLED=true in .env.
+  # Clients that use latitude as their DNS server will resolve
+  # OVERWRITEHOST → NEXTCLOUD_LOCAL_IP directly, bypassing Fritz!Box NAT.
+  dnsmasq:
+    image: drewonthenet/dnsmasq:latest
+    restart: unless-stopped
+    profiles:
+      - split-dns
+    ports:
+      - "${NEXTCLOUD_LOCAL_IP:-0.0.0.0}:53:53/udp"
+      - "${NEXTCLOUD_LOCAL_IP:-0.0.0.0}:53:53/tcp"
+    cap_add:
+      - NET_ADMIN
+    command: >
+      --no-resolv
+      --server=${DNS_UPSTREAM:-192.168.178.1}
+      --address=/${OVERWRITEHOST:-nextcloud.example.com}/${NEXTCLOUD_LOCAL_IP:-127.0.0.1}
+      --log-queries
     networks:
       - nextcloud_net
 

--- a/nextcloud/sync-to-mirror.sh
+++ b/nextcloud/sync-to-mirror.sh
@@ -121,23 +121,26 @@ sudo env LANG=C LC_ALL=C tar -czC "$NEXTCLOUD_DATA_DIR/nextcloud" config custom_
          rm -rf '$MIRROR_DATA_DIR/nextcloud/config' '$MIRROR_DATA_DIR/nextcloud/custom_apps' && \
          tar -xzC '$MIRROR_DATA_DIR/nextcloud'"
 
-# ── 4b. Patch config.php on mirror to use mirror's DB credentials ─────────────
-# The streamed config.php contains the SOURCE's dbpassword/dbuser which may
-# differ from what the MIRROR's PostgreSQL was initialised with.
-# We overwrite those three keys with the values from this .env so the mirror
-# can always connect to its own database.
-POSTGRES_PASSWORD_ESC="${POSTGRES_PASSWORD//\//\\/}"   # escape forward slashes for sed
-POSTGRES_USER_ESC="${POSTGRES_USER//\//\\/}"
-log "    Patching mirror config.php with correct DB credentials ..."
-remote "CFGFILE='$MIRROR_DATA_DIR/nextcloud/config/config.php'; \
-    if [ -f \"\$CFGFILE\" ]; then \
-        sed -i.bak \
-            -e \"s/'dbuser' => '[^']*'/'dbuser' => '${POSTGRES_USER_ESC}'/\" \
-            -e \"s/'dbpassword' => '[^']*'/'dbpassword' => '${POSTGRES_PASSWORD_ESC}'/\" \
-            \"\$CFGFILE\" && rm -f \"\${CFGFILE}.bak\" && echo 'config.php patched'; \
-    else \
-        echo 'WARNING: config.php not found on mirror, skipping patch'; \
-    fi"
+# ── 4b. Patch config.php on mirror ────────────────────────────────────────────
+# Remove source-specific redirect overrides and update DB credentials so the
+# mirror connects to its own PostgreSQL.
+# Uses grep -v (universally available) + perl env-var trick (no quoting hell).
+log "    Patching mirror config.php (DB creds, removing redirect overrides) ..."
+MIRROR_CFG="$MIRROR_DATA_DIR/nextcloud/config/config.php"
+ssh -p "$MIRROR_SSH_PORT" "${MIRROR_USER}@${MIRROR_HOST}" \
+    "export PATH='${MIRROR_EXTRA_PATH}:/usr/local/bin:/usr/bin:/bin'
+     CFG='${MIRROR_CFG}'
+     [ -f \"\$CFG\" ] || { echo 'WARNING: config.php not found on mirror, skipping patch'; exit 0; }
+     # 1. Remove source-specific redirect / overwrite keys
+     TMPF=\$(mktemp)
+     grep -v -E \"'(overwritehost|overwriteprotocol|overwritewebroot)'\" \"\$CFG\" > \"\$TMPF\" && mv \"\$TMPF\" \"\$CFG\"
+     # 2+3. Patch dbuser and dbpassword – pass values via env vars to avoid quoting issues
+     NC_DB_USER='${POSTGRES_USER}' NC_DB_PASS='${POSTGRES_PASSWORD}' perl -i -pe '
+         s|(.\x27dbuser\x27\s*=>\s*\x27)[^\x27]*(\x27)|\$1\$ENV{NC_DB_USER}\$2|;
+         s|(.\x27dbpassword\x27\s*=>\s*\x27)[^\x27]*(\x27)|\$1\$ENV{NC_DB_PASS}\$2|;
+     ' \"\$CFG\"
+     echo 'config.php patched OK'
+    "
 log "    Config synced."
 
 # ── 5. Rsync user data incrementally (no temp files, no compression overhead) ─
@@ -194,6 +197,13 @@ fi
 log "==> Running occ upgrade + repair on mirror ..."
 remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ upgrade 2>/dev/null || true && \
         docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ maintenance:repair 2>/dev/null || true"
+
+# Ensure localhost and the mirror hostname are trusted on the mirror instance
+log "==> Setting trusted_domains on mirror (localhost + $MIRROR_HOST) ..."
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud \
+    php occ config:system:set trusted_domains 0 --value='localhost' 2>/dev/null || true"
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud \
+    php occ config:system:set trusted_domains 1 --value='$MIRROR_HOST' 2>/dev/null || true"
 
 log "==> Disabling maintenance mode on mirror ..."
 remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ maintenance:mode --off 2>/dev/null || true"

--- a/nextcloud/sync-to-mirror.sh
+++ b/nextcloud/sync-to-mirror.sh
@@ -217,5 +217,5 @@ log "═════════════════════════
 log "==> Sync complete. Log: $LOG"
 log ""
 log "Tip: Add to crontab for nightly sync:"
-log "  0 3 * * * /path/to/nextcloud/sync-to-mirror.sh >> /var/log/nc-mirror.log 2>&1"
+log "  0 3 * * * /path/to/nextcloud/sync-to-mirror.sh >> /var/log/nc-mirror-\$(date +\%Y\%m\%d).log 2>&1"
 

--- a/nextcloud/sync-to-mirror.sh
+++ b/nextcloud/sync-to-mirror.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# sync-to-mirror.sh  –  Live sync Nextcloud (source) → mirror server
+#
+# Streams data directly source → mirror without a temporary archive on disk:
+#   1. PostgreSQL dump  → piped via SSH → mirror psql restore
+#   2. Nextcloud config → tar pipe via SSH → mirror tar extract
+#   3. Nextcloud data   → rsync over SSH (incremental, no temp files)
+#
+# Usage:
+#   ./sync-to-mirror.sh [mirror-host] [mirror-nextcloud-dir]
+#
+# Examples:
+#   ./sync-to-mirror.sh mirror.example.com /opt/nextcloud
+#   MIRROR_HOST=192.168.1.50 ./sync-to-mirror.sh
+#
+# Requirements:
+#   - SSH key-based access to the mirror host (no password prompt)
+#   - Docker Compose running on both source and mirror
+#   - rsync installed on both hosts
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$SCRIPT_DIR/.env" ] && source "$SCRIPT_DIR/.env"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+MIRROR_HOST="${1:-${MIRROR_HOST:-}}"
+MIRROR_DIR="${2:-${MIRROR_NEXTCLOUD_DIR:-/opt/nextcloud}}"
+# Data root on the mirror – mirrors NEXTCLOUD_DATA_DIR on the mirror host.
+# Defaults to MIRROR_DIR for setups where compose and data share the same parent.
+MIRROR_DATA_DIR="${MIRROR_DATA_DIR:-$MIRROR_DIR}"
+MIRROR_USER="${MIRROR_USER:-$(whoami)}"
+MIRROR_SSH_PORT="${MIRROR_SSH_PORT:-22}"
+MIRROR_SHELL="${MIRROR_SHELL:-zsh}"
+MIRROR_EXTRA_PATH="${MIRROR_EXTRA_PATH:-/usr/local/bin}"
+
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+POSTGRES_DB="${POSTGRES_DB:-nextcloud}"
+POSTGRES_USER="${POSTGRES_USER:-nextcloud}"
+NEXTCLOUD_DATA_DIR="${NEXTCLOUD_DATA_DIR:-$SCRIPT_DIR/data}"
+
+LOG="$SCRIPT_DIR/sync-mirror-$(date +%Y%m%d_%H%M%S).log"
+log() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+# ── Validate ──────────────────────────────────────────────────────────────────
+if [ -z "$MIRROR_HOST" ]; then
+    echo "ERROR: No mirror host specified."
+    echo "Usage: $0 <mirror-host> [mirror-nextcloud-dir]"
+    echo "   or: set MIRROR_HOST in .env"
+    exit 1
+fi
+
+# Use login shell on mirror so PATH includes docker/docker compose
+# MIRROR_SHELL=zsh for macOS, bash for Linux
+SSH="ssh -p $MIRROR_SSH_PORT ${MIRROR_USER}@${MIRROR_HOST} $MIRROR_SHELL -l -c"
+RSYNC_SSH="ssh -p $MIRROR_SSH_PORT"
+
+# Wrapper: prepend MIRROR_EXTRA_PATH so docker is always found.
+# Does NOT use a login shell to avoid .zprofile/.bashrc side effects.
+# Uses explicit -f path so docker compose always finds its config.
+MIRROR_COMPOSE="$MIRROR_DIR/docker-compose.yml"
+remote() {
+    ssh -p "$MIRROR_SSH_PORT" "${MIRROR_USER}@${MIRROR_HOST}" \
+        "export PATH='${MIRROR_EXTRA_PATH}:/usr/local/bin:/usr/bin:/bin'; $1"
+}
+
+log "==> Sync started"
+log "    Source       : $(hostname) → $NEXTCLOUD_DATA_DIR"
+log "    Mirror       : ${MIRROR_USER}@${MIRROR_HOST}:${MIRROR_DIR}"
+log "    Mirror data  : ${MIRROR_USER}@${MIRROR_HOST}:${MIRROR_DATA_DIR}"
+log "    Log          : $LOG"
+echo ""
+
+# Test SSH connectivity
+if ! remote 'docker info > /dev/null 2>&1'; then
+    log "ERROR: Cannot reach docker on mirror host."
+    log "       Check MIRROR_SHELL ($MIRROR_SHELL) and MIRROR_EXTRA_PATH ($MIRROR_EXTRA_PATH)"
+    log "       Test manually: ssh ${MIRROR_USER}@${MIRROR_HOST} $MIRROR_SHELL -l -c 'export PATH=${MIRROR_EXTRA_PATH}:\$PATH; docker info'"
+    exit 1
+fi
+
+# ── 1. Enable maintenance mode on source ─────────────────────────────────────
+log "==> Enabling maintenance mode on source ..."
+docker compose -f "$COMPOSE_FILE" exec -T --user www-data nextcloud \
+    php occ maintenance:mode --on 2>/dev/null || true
+
+# ── 2. Enable maintenance mode on mirror (if Nextcloud is running there) ──────
+# Suppress all output: on first sync html is empty so occ fails – that's ok.
+log "==> Enabling maintenance mode on mirror (if running) ..."
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ maintenance:mode --on >/dev/null 2>&1 || true" || true
+
+# ── 3. Stream PostgreSQL dump directly to mirror ──────────────────────────────
+log "==> Streaming PostgreSQL '$POSTGRES_DB' source → mirror ..."
+
+# Step 3a: prepare the target DB on mirror (runs before the dump pipe so it
+#          does NOT accidentally consume any of the pg_dump stdin stream)
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T db psql -U '$POSTGRES_USER' postgres \
+    -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+         WHERE datname='$POSTGRES_DB' AND pid <> pg_backend_pid();\" \
+    -c \"DROP DATABASE IF EXISTS \\\"$POSTGRES_DB\\\";\" \
+    -c \"CREATE DATABASE \\\"$POSTGRES_DB\\\" OWNER \\\"$POSTGRES_USER\\\";\""
+
+# Step 3b: stream the dump directly into the freshly created DB
+# --no-owner --no-acl strips ownership/privilege statements so roles that
+# existed only on the source (e.g. legacy "oc_admin") don't cause errors.
+docker compose -f "$COMPOSE_FILE" exec -T db \
+    pg_dump -U "$POSTGRES_USER" --no-owner --no-acl "$POSTGRES_DB" \
+    | ssh -p "$MIRROR_SSH_PORT" "${MIRROR_USER}@${MIRROR_HOST}" \
+        "export PATH='${MIRROR_EXTRA_PATH}:/usr/local/bin:/usr/bin:/bin'; \
+         docker compose -f '$MIRROR_COMPOSE' exec -T db \
+             psql -U '$POSTGRES_USER' '$POSTGRES_DB'"
+log "    Database synced."
+
+# ── 4. Stream config + custom_apps via tar pipe ───────────────────────────────
+log "==> Streaming Nextcloud config → mirror ..."
+sudo env LANG=C LC_ALL=C tar -czC "$NEXTCLOUD_DATA_DIR/nextcloud" config custom_apps \
+    | ssh -p "$MIRROR_SSH_PORT" "${MIRROR_USER}@${MIRROR_HOST}" \
+        "export PATH='${MIRROR_EXTRA_PATH}:/usr/local/bin:/usr/bin:/bin'; \
+         mkdir -p '$MIRROR_DATA_DIR/nextcloud' && \
+         rm -rf '$MIRROR_DATA_DIR/nextcloud/config' '$MIRROR_DATA_DIR/nextcloud/custom_apps' && \
+         tar -xzC '$MIRROR_DATA_DIR/nextcloud'"
+
+# ── 4b. Patch config.php on mirror to use mirror's DB credentials ─────────────
+# The streamed config.php contains the SOURCE's dbpassword/dbuser which may
+# differ from what the MIRROR's PostgreSQL was initialised with.
+# We overwrite those three keys with the values from this .env so the mirror
+# can always connect to its own database.
+POSTGRES_PASSWORD_ESC="${POSTGRES_PASSWORD//\//\\/}"   # escape forward slashes for sed
+POSTGRES_USER_ESC="${POSTGRES_USER//\//\\/}"
+log "    Patching mirror config.php with correct DB credentials ..."
+remote "CFGFILE='$MIRROR_DATA_DIR/nextcloud/config/config.php'; \
+    if [ -f \"\$CFGFILE\" ]; then \
+        sed -i.bak \
+            -e \"s/'dbuser' => '[^']*'/'dbuser' => '${POSTGRES_USER_ESC}'/\" \
+            -e \"s/'dbpassword' => '[^']*'/'dbpassword' => '${POSTGRES_PASSWORD_ESC}'/\" \
+            \"\$CFGFILE\" && rm -f \"\${CFGFILE}.bak\" && echo 'config.php patched'; \
+    else \
+        echo 'WARNING: config.php not found on mirror, skipping patch'; \
+    fi"
+log "    Config synced."
+
+# ── 5. Rsync user data incrementally (no temp files, no compression overhead) ─
+log "==> Rsyncing user data source → mirror (incremental) ..."
+rsync -av --delete \
+    -e "ssh -p $MIRROR_SSH_PORT" \
+    "$NEXTCLOUD_DATA_DIR/nextcloud/data/" \
+    "${MIRROR_USER}@${MIRROR_HOST}:${MIRROR_DATA_DIR}/nextcloud/data/" \
+    2>&1 | tee -a "$LOG" | grep -E '(^sending|^deleting|/$|^sent|^total)' || true
+log "    User data synced."
+
+# ── 6. Down + up mirror Nextcloud so html/ is (re-)populated by the entrypoint ─
+# "restart" does NOT re-run the image's init script – only "down && up -d" does.
+log "==> Stopping mirror Nextcloud container ..."
+remote "docker compose -f '$MIRROR_COMPOSE' down --remove-orphans 2>/dev/null || true"
+
+log "==> Starting mirror Nextcloud container (html will be re-populated) ..."
+remote "docker compose -f '$MIRROR_COMPOSE' up -d"
+
+# Wait up to 20 min for the entrypoint to finish installing Nextcloud into html/
+# macOS Docker Desktop bind-mounts are slow – copying the Nextcloud web root can
+# take 10+ minutes on first run or after a full re-pull.
+MAX_WAIT=240   # iterations
+WAIT_SEC=5
+log "    Waiting for mirror Nextcloud to finish initialising (max ${MAX_WAIT} * ${WAIT_SEC} s = $((MAX_WAIT * WAIT_SEC / 60)) min) ..."
+MIRROR_UP=false
+for i in $(seq 1 $MAX_WAIT); do
+    sleep $WAIT_SEC
+    # Check if the nextcloud container is up AND html/lib/versioncheck.php exists
+    VERSION_CHECK=$(remote "docker compose -f '$MIRROR_COMPOSE' exec -T nextcloud \
+        test -f /var/www/html/lib/versioncheck.php && echo OK || echo MISSING" 2>/dev/null || echo MISSING)
+    if [ "$VERSION_CHECK" = "OK" ]; then
+        log "    Mirror Nextcloud is up and html/ is populated (${i} * ${WAIT_SEC} s = $((i * WAIT_SEC)) s)."
+        MIRROR_UP=true
+        break
+    fi
+    # Print progress every 12 iterations (= 1 minute)
+    if (( i % 12 == 0 )); then
+        ELAPSED=$(( i * WAIT_SEC ))
+        log "    Still initialising ... ${ELAPSED}s elapsed (html/lib/versioncheck.php not yet present)"
+    fi
+done
+
+if [ "$MIRROR_UP" != "true" ]; then
+    log "WARNING: Mirror did not finish initialising within $(( MAX_WAIT * WAIT_SEC / 60 )) minutes."
+    log "         The Nextcloud entrypoint is still copying files into the bind-mounted html/ directory."
+    log "         This is expected on macOS Docker Desktop with a fresh or re-pulled image."
+    log "         Suggestions:"
+    log "           1. Wait a few more minutes then re-run occ manually:"
+    log "              ssh ${MIRROR_USER}@${MIRROR_HOST} 'cd $MIRROR_DIR && docker compose exec --user www-data nextcloud php occ upgrade'"
+    log "           2. Check mirror logs: ssh ${MIRROR_USER}@${MIRROR_HOST} 'cd $MIRROR_DIR && docker compose logs nextcloud'"
+fi
+
+log "==> Running occ upgrade + repair on mirror ..."
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ upgrade 2>/dev/null || true && \
+        docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ maintenance:repair 2>/dev/null || true"
+
+log "==> Disabling maintenance mode on mirror ..."
+remote "docker compose -f '$MIRROR_COMPOSE' exec -T --user www-data nextcloud php occ maintenance:mode --off 2>/dev/null || true"
+
+# ── 7. Disable maintenance mode on source ────────────────────────────────────
+log "==> Disabling maintenance mode on source ..."
+docker compose -f "$COMPOSE_FILE" exec -T --user www-data nextcloud \
+    php occ maintenance:mode --off
+
+log "══════════════════════════════════════════"
+log "==> Sync complete. Log: $LOG"
+log ""
+log "Tip: Add to crontab for nightly sync:"
+log "  0 3 * * * /path/to/nextcloud/sync-to-mirror.sh >> /var/log/nc-mirror.log 2>&1"
+

--- a/nextcloud/sync-to-mirror.sh
+++ b/nextcloud/sync-to-mirror.sh
@@ -145,11 +145,11 @@ log "    Config synced."
 
 # ── 5. Rsync user data incrementally (no temp files, no compression overhead) ─
 log "==> Rsyncing user data source → mirror (incremental) ..."
-rsync -av --delete \
+sudo rsync -av --delete \
     -e "ssh -p $MIRROR_SSH_PORT" \
     "$NEXTCLOUD_DATA_DIR/nextcloud/data/" \
     "${MIRROR_USER}@${MIRROR_HOST}:${MIRROR_DATA_DIR}/nextcloud/data/" \
-    2>&1 | tee -a "$LOG" | grep -E '(^sending|^deleting|/$|^sent|^total)' || true
+    2>&1 | tee -a "$LOG" | grep -E '(^sending|^deleting|/$|^sent|^total)'
 log "    User data synced."
 
 # ── 6. Down + up mirror Nextcloud so html/ is (re-)populated by the entrypoint ─


### PR DESCRIPTION
# Set up SSH key auth first (one-time)
ssh-copy-id hannes@mirror-host

# Add to .env

```
MIRROR_HOST=192.168.178.50
MIRROR_USER=hannes
MIRROR_NEXTCLOUD_DIR=/opt/nextcloud
```

# Run sync
```
cd nextcloud
./sync-to-mirror.sh
```
What it does — all streamed, no temp files:

| Step |Method |
| --- | --- |
| PostgreSQL $${\color{red}pg_dump}$$ | → pipe over SSH → $${\color{red}psql}$$ on mirror |
| Config/apps $${\color{red}tar -cz}$$ |→ pipe over SSH → $${\color{red}tar -xz}$$ on mirror |
| User data $${\color{red}rsync}$$ |over SSH (incremental, only changed files) |

Both source and mirror go into maintenance mode during the sync to keep data consistent